### PR TITLE
MessageBox + CreateTimerQueueTimer

### DIFF
--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -103,6 +103,7 @@ var winTypes = function() {
 	this.LPOLESTR = this.OLECHAR.ptr; // typedef [string] OLECHAR *LPOLESTR; // https://github.com/wine-mirror/wine/blob/bdeb761357c87d41247e0960f71e20d3f05e40e6/include/wtypes.idl#L287 // http://stackoverflow.com/a/1607335/1828637 // LPOLESTR is usually to be allocated with CoTaskMemAlloc()
 	this.LPTSTR = ifdef_UNICODE ? this.LPWSTR : this.LPSTR;
 	this.PCTSTR = ifdef_UNICODE ? this.LPCWSTR : this.LPCSTR;
+	this.PHANDLE = this.HANDLE.ptr;
 	this.PCZZTSTR = this.PCZZSTR; // double null terminated from msdn docs // typedef from https://github.com/wine-mirror/wine/blob/b1ee60f22fbd6b854c3810a89603458ec0585369/include/winnt.h#L535
 
 	// SUPER DUPER ADVANCED TYPES // defined by "super advanced types"
@@ -736,9 +737,9 @@ var winInit = function() {
 			*/
 			return lib('kernel32').declare("CreateTimerQueueTimer", self.TYPE.ABI,
 				self.TYPE.BOOL,												// return
-				self.TYPE.HANDLE.ptr,									// phNewTimer
+				self.TYPE.PHANDLE,											// phNewTimer
 				self.TYPE.HANDLE,											// TimerQueue
-				self.TYPE.WAITORTIMERCALLBACK.ptr,		// Callback,
+				self.TYPE.WAITORTIMERCALLBACK.ptr,							// Callback,
 				self.TYPE.PVOID,											// Parameter,
 				self.TYPE.DWORD,											// DueTime,
 				self.TYPE.DWORD,											// Period,
@@ -1148,8 +1149,8 @@ var winInit = function() {
 			return lib('user32').declare(ifdef_UNICODE ? 'MessageBoxW' : 'MessageBoxA', self.TYPE.ABI,
 				self.TYPE.INT,			// return
 				self.TYPE.HWND, 		// hWnd
-				self.TYPE.LPCTSTR,	// lpText
-				self.TYPE.LPCTSTR,	// lpCaption
+				self.TYPE.LPCTSTR,		// lpText
+				self.TYPE.LPCTSTR,		// lpCaption
 				self.TYPE.UINT			// uType
 			);
 		},

--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -736,11 +736,12 @@ var winInit = function() {
 			*/
 			return lib('kernel32').declare("CreateTimerQueueTimer", self.TYPE.ABI,
 				self.TYPE.BOOL,												// return
-				self.TYPE.HANDLE,											// phNewTimer
+				self.TYPE.HANDLE.ptr,									// phNewTimer
+				self.TYPE.HANDLE,											// TimerQueue
 				self.TYPE.WAITORTIMERCALLBACK.ptr,		// Callback,
 				self.TYPE.PVOID,											// Parameter,
 				self.TYPE.DWORD,											// DueTime,
-				self.TYPE.PERIOD,											// Period,
+				self.TYPE.DWORD,											// Period,
 				self.TYPE.ULONG												// Flags
 			);
 		},
@@ -1150,7 +1151,7 @@ var winInit = function() {
 				self.TYPE.LPCTSTR,	// lpText
 				self.TYPE.LPCTSTR,	// lpCaption
 				self.TYPE.UINT			// uType
-			);	
+			);
 		},
 		PostMessage: function() {
 			/* https://msdn.microsoft.com/en-us/library/windows/desktop/ms644944%28v=vs.85%29.aspx

--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -72,7 +72,7 @@ var winTypes = function() {
 	this.LPWSTR = this.WCHAR.ptr;
 	this.LRESULT = this.LONG_PTR;
 	this.OLECHAR = this.WCHAR; // typedef WCHAR OLECHAR; // https://github.com/wine-mirror/wine/blob/bdeb761357c87d41247e0960f71e20d3f05e40e6/include/wtypes.idl#L286
-	this.PCZZSTR = ifdef_UNICODE ? this.WCHAR.ptr : this.CHAR.ptr; // EDUCATED GUESS BASED ON TYPEDEF FROM --> // ansi / unicode - https://github.com/wine-mirror/wine/blob/b1ee60f22fbd6b854c3810a89603458ec0585369/include/winnt.h#L483 --- 
+	this.PCZZSTR = ifdef_UNICODE ? this.WCHAR.ptr : this.CHAR.ptr; // EDUCATED GUESS BASED ON TYPEDEF FROM --> // ansi / unicode - https://github.com/wine-mirror/wine/blob/b1ee60f22fbd6b854c3810a89603458ec0585369/include/winnt.h#L483 ---
 	this.PLONG = this.LONG.ptr;
 	this.PULONG = this.ULONG.ptr;
 	this.PULONG_PTR = this.ULONG.ptr;
@@ -104,7 +104,7 @@ var winTypes = function() {
 	this.LPTSTR = ifdef_UNICODE ? this.LPWSTR : this.LPSTR;
 	this.PCTSTR = ifdef_UNICODE ? this.LPCWSTR : this.LPCSTR;
 	this.PCZZTSTR = this.PCZZSTR; // double null terminated from msdn docs // typedef from https://github.com/wine-mirror/wine/blob/b1ee60f22fbd6b854c3810a89603458ec0585369/include/winnt.h#L535
-	
+
 	// SUPER DUPER ADVANCED TYPES // defined by "super advanced types"
 	this.HCURSOR = this.HICON;
 	this.HMODULE = this.HINSTANCE;
@@ -335,10 +335,10 @@ var winTypes = function() {
 	this.LPMONITORINFOEX = this.MONITORINFOEX.ptr;
 	this.LPMSG = this.MSG.ptr;
 	this.PMSG = this.MSG.ptr
-	
+
 	// FURTHER ADV STRUCTS
 	this.PBITMAPINFO = this.BITMAPINFO.ptr;
-	
+
 	// FUNCTION TYPES
 	this.MONITORENUMPROC = ctypes.FunctionType(this.CALLBACK_ABI, this.BOOL, [this.HMONITOR, this.HDC, this.LPRECT, this.LPARAM]);
 	this.LowLevelMouseProc = ctypes.FunctionType(this.CALLBACK_ABI, this.LRESULT, [this.INT, this.WPARAM, this.LPARAM]);
@@ -349,10 +349,14 @@ var winTypes = function() {
 		this.LPARAM	// lParam
 	]);
 	this.TIMERPROC = ctypes.FunctionType(this.CALLBACK_ABI, this.VOID, [this.HWND, this.UINT, this.UINT_PTR, this.DWORD]);
+	this.WAITORTIMERCALLBACK = ctypes.FunctionType(this.CALLBACK_ABI, this.VOID, [
+		this.PVOID,			// lpParameter,
+		this.BOOLEAN		// TimerOrWaitFired
+	]);
 
 	// ADV FUNC TYPES
 	this.HOOKPROC = this.LowLevelMouseProc.ptr; // not a guess really, as this is the hook type i use, so yeah it has to be a pointer to it
-	
+
 	// STRUCTS USING FUNC TYPES
 	this.WNDCLASS = ctypes.StructType('tagWNDCLASS', [
 		{ style: this.UINT },
@@ -366,7 +370,6 @@ var winTypes = function() {
 		{ lpszMenuName: this.LPCTSTR },
 		{ lpszClassName: this.LPCTSTR }
 	]);
-	
 }
 
 var winInit = function() {
@@ -421,14 +424,14 @@ var winInit = function() {
 		FOF_NOCONFIRMATION: 16,
 		FOF_NOERRORUI: 1024,
 		// FOF_NOCONFIRMMKDIR: ,
-		// FOF_WANTNUKEWARNING: 
-		
+		// FOF_WANTNUKEWARNING:
+
 		PM_REMOVE: 1,
 		WM_HOTKEY: 0x0312,
 		MOD_NOREPEAT: 0x4000,
 		VK_SNAPSHOT: 0x2C,
 		VK_SCROLL: 0x91,
-		
+
 		WM_MOUSEMOVE: 0x200,
 		WM_LBUTTONDOWN: 0x201,
 		WM_LBUTTONUP: 0x202,
@@ -472,7 +475,7 @@ var winInit = function() {
 		RI_MOUSE_HORIZONTAL_WHEEL: 0x0800,
 		XBUTTON1: 0x0001,
 		XBUTTON2: 0x0002,
-		
+
 		QS_ALLEVENTS: 0x04BF,
 		QS_ALLINPUT: 0x04FF,
 		WAIT_ABANDONED_0: 0x00000080, // 128
@@ -480,7 +483,7 @@ var winInit = function() {
 		WAIT_IO_COMPLETION: 0x000000C0, // 192
 		WAIT_OBJECT_0: 0,
 		WAIT_TIMEOUT: 0x00000102, // 258
-		
+
 		GENERIC_READ: 0x80000000,
 		GENERIC_WRITE: 0x40000000,
 		CREATE_NEW: 1,
@@ -611,7 +614,7 @@ var winInit = function() {
 			 *   __in_     int    nCode,
 			 *   __in_     WPARAM wParam,
 			 *   __in_     LPARAM lParam
-			 * );			
+			 * );
 			 */
 			return lib('user32').declare('CallNextHookEx', self.TYPE.ABI,
 				self.TYPE.LRESULT,
@@ -717,6 +720,28 @@ var winInit = function() {
 				self.TYPE.DWORD,					// dwCreationDisposition
 				self.TYPE.DWORD,					// dwFlagsAndAttributes
 				self.TYPE.HANDLE					// hTemplateFile
+			);
+		},
+		CreateTimerQueueTimer: function() {
+			/* https://msdn.microsoft.com/en-us/library/windows/desktop/ms682485(v=vs.85).aspx
+				 BOOL WINAPI CreateTimerQueueTimer(
+				  _Out_    PHANDLE             phNewTimer,
+				  _In_opt_ HANDLE              TimerQueue,
+				  _In_     WAITORTIMERCALLBACK Callback,
+				  _In_opt_ PVOID               Parameter,
+				  _In_     DWORD               DueTime,
+				  _In_     DWORD               Period,
+				  _In_     ULONG               Flags
+				);
+			*/
+			return lib('kernel32').declare("CreateTimerQueueTimer", self.TYPE.ABI,
+				self.TYPE.BOOL,												// return
+				self.TYPE.HANDLE,											// phNewTimer
+				self.TYPE.WAITORTIMERCALLBACK.ptr,		// Callback,
+				self.TYPE.PVOID,											// Parameter,
+				self.TYPE.DWORD,											// DueTime,
+				self.TYPE.PERIOD,											// Period,
+				self.TYPE.ULONG												// Flags
 			);
 		},
 		CreateWindowEx: function() {

--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -1135,6 +1135,23 @@ var winInit = function() {
 				self.TYPE.UINT_PTR	// uIDEvent
 			);
 		},
+		MessageBox: function() {
+			/*	https://msdn.microsoft.com/en-us/library/windows/desktop/ms645505(v=vs.85).aspx
+				int WINAPI MessageBox(
+				  _In_opt_ HWND    hWnd,
+				  _In_opt_ LPCTSTR lpText,
+				  _In_opt_ LPCTSTR lpCaption,
+				  _In_     UINT    uType
+				);
+			*/
+			return lib('user32').declare(ifdef_UNICODE ? 'MessageBoxW' : 'MessageBox', self.TYPE.ABI,
+				self.TYPE.INT,			// return
+				self.TYPE.HWND, 		// hWnd
+				self.TYPE.LPCTSTR,	// lpText
+				self.TYPE.LPCTSTR,	// lpCaption
+				self.TYPE.UINT			// uType
+			);	
+		},
 		PostMessage: function() {
 			/* https://msdn.microsoft.com/en-us/library/windows/desktop/ms644944%28v=vs.85%29.aspx
 			 * BOOL WINAPI PostMessage(

--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -1145,7 +1145,7 @@ var winInit = function() {
 				  _In_     UINT    uType
 				);
 			*/
-			return lib('user32').declare(ifdef_UNICODE ? 'MessageBoxW' : 'MessageBox', self.TYPE.ABI,
+			return lib('user32').declare(ifdef_UNICODE ? 'MessageBoxW' : 'MessageBoxA', self.TYPE.ABI,
 				self.TYPE.INT,			// return
 				self.TYPE.HWND, 		// hWnd
 				self.TYPE.LPCTSTR,	// lpText


### PR DESCRIPTION
The MessageBox works fine, however, I'm still having problems with CreateTimerQueueTimer. The timer runs and a signal is sent, but the moment it is, Firefox crashes. It is really quite dramatic. Currently I'm calling it with

```
function jsCallback(lpParameter, TimerOrWaitFired) {
  self.postMessage('lpParameter: ' + lpParameter);
  self.PostMessage('TimerOrWaitFired: ' + TimerOrWaitFired);
  return undefined;
}

var hNewTimer = ostypes.TYPE.HANDLE(0);
ret = ostypes.API('CreateTimerQueueTimer')(
  hNewTimer.address(),
  ostypes.TYPE.HANDLE(0),
  ostypes.TYPE.WAITORTIMERCALLBACK.ptr(jsCallback),
  ostypes.TYPE.PVOID(0),
  5000,
  0,
  0x00000000
);
```

It waits 5000 ms, then Firefox crashes. Any tips much appreciated.
