### PR TITLE
Assign top-level global, rather than use 'this' directly

### DIFF
--- a/ostypes_mac.jsm
+++ b/ostypes_mac.jsm
@@ -17,7 +17,8 @@ if (ctypes.voidptr_t.size == 4 /* 32-bit */) {
 }
 
 var osname;
-if (this.DedicatedWorkerGlobalScope) {
+var global = this;
+if (global.DedicatedWorkerGlobalScope) {
 	osname = OS.Constants.Sys.Name.toLowerCase();
 } else {
 	importServicesJsm();
@@ -2133,7 +2134,7 @@ var macInit = function() {
 
 // helper function
 function importServicesJsm() {
-	if (!this.DedicatedWorkerGlobalScope && typeof(Services) == 'undefined') {
+	if (!global.DedicatedWorkerGlobalScope && typeof(Services) == 'undefined') {
 		if (typeof(Cu) == 'undefined') {
 			if (typeof(Components) != 'undefined') {
 				// Bootstrap
@@ -2152,7 +2153,7 @@ function importServicesJsm() {
 }
 
 function importOsConstsJsm() {
-	if (!this.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
+	if (!global.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
 		if (typeof(Cu) == 'undefined') {
 			if (typeof(Components) != 'undefined') {
 				// Bootstrap

--- a/ostypes_win.jsm
+++ b/ostypes_win.jsm
@@ -18,7 +18,8 @@ if (ctypes.voidptr_t.size == 4 /* 32-bit */) {
 
 var ifdef_UNICODE = true;
 
-if (this.DedicatedWorkerGlobalScope) {
+var global = this;
+if (global.DedicatedWorkerGlobalScope) {
 	// osname = OS.Constants.Sys.Name.toLowerCase();
 	// i dont use `osname` in ostypes_win.jsm
 } else {
@@ -4788,7 +4789,7 @@ var winInit = function() {
 var ostypes = new winInit();
 
 function importOsConstsJsm() {
-	if (!this.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
+	if (!global.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
 		if (typeof(Cu) == 'undefined') {
 			if (typeof(Components) != 'undefined') {
 				// Bootstrap
@@ -4808,7 +4809,7 @@ function importOsConstsJsm() {
 
 function ostypesSyncXhrText(url) {
 	// xhr's the url and returns the text response
-	if (this.DedicatedWorkerGlobalScope) {
+	if (global.DedicatedWorkerGlobalScope) {
 		var req = new XMLHttpRequest();
 	} else {
 		if (typeof(Cu) == 'undefined') {

--- a/ostypes_x11.jsm
+++ b/ostypes_x11.jsm
@@ -8,15 +8,16 @@ var EXPORTED_SYMBOLS = ['ostypes'];
 
 // no need to define core or import cutils as all the globals of the worker who importScripts'ed it are availble here
 
-if (!this.DedicatedWorkerGlobalScope) {
+var global = this;
+if (!global.DedicatedWorkerGlobalScope) {
 	importOsConstsJsm(); // needed for access OS.Constants.libc
 	importServicesJsm();
 }
 
 const APP_64BIT = ctypes.voidptr_t.size === 4 ? false : true;
-const OS_NAME = this.DedicatedWorkerGlobalScope ? OS.Constants.Sys.Name.toLowerCase() : Services.appinfo.OS.toLowerCase(); // lower case platform name
-const FIREFOX_VERSION = this.DedicatedWorkerGlobalScope ? parseFloat(/Firefox\/(\d+\.\d+)/.exec(navigator.userAgent)[1]) : Services.appinfo.version; // not used for anything right now
-Object.defineProperty(this, 'GTK_VERSION', { get: function() { return getGtkVersion() } }); // make this a getter, so that ostyeps can be loaded without needing to have first got `TOOLKIT` from mainthread if this is a worker
+const OS_NAME = global.DedicatedWorkerGlobalScope ? OS.Constants.Sys.Name.toLowerCase() : Services.appinfo.OS.toLowerCase(); // lower case platform name
+const FIREFOX_VERSION = global.DedicatedWorkerGlobalScope ? parseFloat(/Firefox\/(\d+\.\d+)/.exec(navigator.userAgent)[1]) : Services.appinfo.version; // not used for anything right now
+Object.defineProperty(global, 'GTK_VERSION', { get: function() { return getGtkVersion() } }); // make this a getter, so that ostyeps can be loaded without needing to have first got `TOOLKIT` from mainthread if this is a worker
 
 var xlibTypes = function() {
 	// ABIs
@@ -4886,7 +4887,7 @@ var x11Init = function() {
 
 // helper function
 function importServicesJsm() {
-	if (!this.DedicatedWorkerGlobalScope && typeof(Services) == 'undefined') {
+	if (!global.DedicatedWorkerGlobalScope && typeof(Services) == 'undefined') {
 		if (typeof(Cu) == 'undefined') {
 			if (typeof(Components) != 'undefined') {
 				// Bootstrap
@@ -4905,7 +4906,7 @@ function importServicesJsm() {
 }
 
 function importOsConstsJsm() {
-	if (!this.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
+	if (!global.DedicatedWorkerGlobalScope && typeof(OS) == 'undefined') {
 		if (typeof(Cu) == 'undefined') {
 			if (typeof(Components) != 'undefined') {
 				// Bootstrap
@@ -4930,7 +4931,7 @@ function getGtkVersion() {
 	if (!getGtkVersion_cache) {
 		var c_toolkit;
 
-		if (!this.DedicatedWorkerGlobalScope) {
+		if (!global.DedicatedWorkerGlobalScope) {
 			c_toolkit = Services.appinfo.widgetToolkit.toLowerCase();
 		} else {
 			// its a worker


### PR DESCRIPTION
Bug 1394556 enforces strict mode for all JSM modules. So far, I've only
seen this issue on Mac OS, see
https://github.com/meandavejustice/min-vid/pull/1029.